### PR TITLE
Fix: add idx column to member&house_item table

### DIFF
--- a/backend/db/models.py
+++ b/backend/db/models.py
@@ -51,6 +51,7 @@ class Item(Base):
 class Member(Base):
     
     __tablename__ = "member" # MySQL DB Table 이름
+    idx = Column(Integer, nullable=False, autoincrement=True, primary_key=True) # 인덱스 (사용 x)
     member_email = Column(String(255), nullable=False) # 회원 email
     house_id = Column(Integer, nullable=False) # 집들이 id
     
@@ -59,6 +60,7 @@ class Member(Base):
 class HouseItem(Base):
     
     __tablename__ = "house_item" # MySQL DB Table 이름
+    idx = Column(Integer, nullable=False, autoincrement=True, primary_key=True) # 인덱스 (사용 x)
     house_id = Column(Integer, nullable=False) # 집들이 id
     item_id = Column(Integer, nullable=False) # 가구 id
     

--- a/database/sql/create_table.sql
+++ b/database/sql/create_table.sql
@@ -40,12 +40,14 @@ CREATE TABLE IF NOT EXISTS `house` (
 
 -- create house_item interaction table
 CREATE TABLE IF NOT EXISTS `house_item`(
+	`idx` INT(10) NOT NULL AUTO_INCREMENT PRIMARY KEY,
 	`house_id` INT(10) NOT NULL,
 	`item_id` INT(10) NOT NULL
 );
 
 -- create member table
 CREATE TABLE IF NOT EXISTS `member` (
+	`idx` INT(10) NOT NULL AUTO_INCREMENT PRIMARY KEY,
 	`member_email` VARCHAR(255) NOT NULL,
 	`house_id`	INT(10)	NOT NULL
 );


### PR DESCRIPTION
## PR 제목
member 테이블과 house_item 테이블에 idx column 추가

### PR 생성일시
* 2023/01/19

### PR 내용
FastAPI에서 primary key가 없는 테이블에 대한 문제가 발생하였고 이를 해결하기 위해
member 테이블과 house_item 테이블에 사용하지 않는 auto_increment가 적용된
idx이라는 이름의 primary key를 추가하여 해당 에러를 해결하고자 합니다.

### PR 유의사항
models.py에도 autoincrement 옵션을 sqlalchemy docs에서 확인 후 적용하였으나 테스트해보지 못한 부분이기에 확인 후 이슈 발생 시 연락 부탁드립니다.